### PR TITLE
feat: add ingress for processors and plain http setup

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,8 +1,8 @@
 ---
 apiVersion: v2
 name: nifi
-version: 1.2.1
-appVersion: 1.23.2
+version: 1.3.0
+appVersion: 1.25.0
 description: Apache NiFi is a software project from the Apache Software Foundation designed to automate the flow of data between software systems.
 keywords:
   - nifi
@@ -27,16 +27,16 @@ maintainers:
     url: https://github.com/zakaria2905
 dependencies:
   - name: zookeeper
-    version: 9.2.7
+    version: 13.1.1
     repository: https://charts.bitnami.com/bitnami
     condition: zookeeper.enabled
   - name: nifi-registry
     alias: registry
-    version: 1.0.0
+    version: 1.1.5
     repository: https://dysnix.github.io/charts/
     condition: registry.enabled
   - name: ca
-    version: 1.0.1
+    version: 1.0.2
     condition: ca.enabled
   - name: openldap
     version: ~1.2.4

--- a/charts/ca/Chart.yaml
+++ b/charts/ca/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: ca
-version: 1.0.1
+version: 1.0.2
 # We are using the nifi version as appVersion
-appVersion: 1.11.4
+appVersion: 1.25.0
 description: A Helm chart to deploy ca server to generate self-signed certificates using nifi-toolkit.
 keywords:
   - nifi-toolkit

--- a/charts/ca/values.yaml
+++ b/charts/ca/values.yaml
@@ -7,7 +7,7 @@ replicaCount: 1
 image:
   repository: apache/nifi-toolkit
   pullPolicy: IfNotPresent
-  tag: "1.12.1"
+  tag: "1.25.0"
 
 service:
   type: ClusterIP

--- a/configs/logback.xml
+++ b/configs/logback.xml
@@ -1,0 +1,261 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+      http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<configuration scan="true" scanPeriod="30 seconds">
+    <shutdownHook class="ch.qos.logback.core.hook.DefaultShutdownHook" />
+
+    <contextListener class="ch.qos.logback.classic.jul.LevelChangePropagator">
+        <resetJUL>true</resetJUL>
+    </contextListener>
+
+    <appender name="APP_FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>${org.apache.nifi.bootstrap.config.log.dir}/nifi-app.log</file>
+        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+            <!--
+              For daily rollover, use 'app_%d.log'.
+              For hourly rollover, use 'app_%d{yyyy-MM-dd_HH}.log'.
+              To GZIP rolled files, replace '.log' with '.log.gz'.
+              To ZIP rolled files, replace '.log' with '.log.zip'.
+            -->
+            <fileNamePattern>${org.apache.nifi.bootstrap.config.log.dir}/nifi-app_%d{yyyy-MM-dd_HH}.%i.log</fileNamePattern>
+            <maxFileSize>100MB</maxFileSize>
+            <!-- keep 30 log files worth of history -->
+            <maxHistory>30</maxHistory>
+        </rollingPolicy>
+        <immediateFlush>true</immediateFlush>
+        <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
+            <pattern>%date %level [%thread] %logger{40} %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <appender name="USER_FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>${org.apache.nifi.bootstrap.config.log.dir}/nifi-user.log</file>
+        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+            <!--
+              For daily rollover, use 'user_%d.log'.
+              For hourly rollover, use 'user_%d{yyyy-MM-dd_HH}.log'.
+              To GZIP rolled files, replace '.log' with '.log.gz'.
+              To ZIP rolled files, replace '.log' with '.log.zip'.
+            -->
+            <fileNamePattern>${org.apache.nifi.bootstrap.config.log.dir}/nifi-user_%d.log</fileNamePattern>
+            <!-- keep 30 log files worth of history -->
+            <maxHistory>30</maxHistory>
+        </rollingPolicy>
+        <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
+            <pattern>%date %level [%thread] %logger{40} %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <appender name="REQUEST_FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>${org.apache.nifi.bootstrap.config.log.dir}/nifi-request.log</file>
+        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+            <fileNamePattern>${org.apache.nifi.bootstrap.config.log.dir}/nifi-request_%d.log</fileNamePattern>
+            <maxHistory>30</maxHistory>
+        </rollingPolicy>
+        <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
+            <pattern>%msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <appender name="BOOTSTRAP_FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>${org.apache.nifi.bootstrap.config.log.dir}/nifi-bootstrap.log</file>
+        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+            <!--
+              For daily rollover, use 'bootstrap_%d.log'.
+              For hourly rollover, use 'bootstrap_%d{yyyy-MM-dd_HH}.log'.
+              To GZIP rolled files, replace '.log' with '.log.gz'.
+              To ZIP rolled files, replace '.log' with '.log.zip'.
+            -->
+            <fileNamePattern>${org.apache.nifi.bootstrap.config.log.dir}/nifi-bootstrap_%d.log</fileNamePattern>
+            <!-- keep 5 log files worth of history -->
+            <maxHistory>5</maxHistory>
+        </rollingPolicy>
+        <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
+            <pattern>%date %level [%thread] %logger{40} %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <appender name="DEPRECATION_FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>${org.apache.nifi.bootstrap.config.log.dir}/nifi-deprecation.log</file>
+        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+            <fileNamePattern>${org.apache.nifi.bootstrap.config.log.dir}/nifi-deprecation_%d.%i.log</fileNamePattern>
+            <maxFileSize>10MB</maxFileSize>
+            <maxHistory>10</maxHistory>
+            <totalSizeCap>100MB</totalSizeCap>
+        </rollingPolicy>
+        <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
+            <pattern>%date %level [%thread] %logger %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <appender name="DEDICATED_LOGGING" class="ch.qos.logback.classic.sift.SiftingAppender">
+        <discriminator class="org.apache.nifi.logging.NifiDiscriminator"/>
+        <sift>
+            <appender name="APP-${logFileSuffix}_FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+                <file>${org.apache.nifi.bootstrap.config.log.dir}/nifi-app-${logFileSuffix}.log</file>
+                <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+                    <!--
+                    For daily rollover, use 'app_%d.log'.
+                    For hourly rollover, use 'app_%d{yyyy-MM-dd_HH}.log'.
+                    To GZIP rolled files, replace '.log' with '.log.gz'.
+                    To ZIP rolled files, replace '.log' with '.log.zip'.
+                    -->
+                    <fileNamePattern>${org.apache.nifi.bootstrap.config.log.dir}/nifi-app-${logFileSuffix}_%d{yyyy-MM-dd_HH}.%i.log</fileNamePattern>
+                    <maxFileSize>100MB</maxFileSize>
+                    <!-- keep 30 log files worth of history -->
+                    <maxHistory>30</maxHistory>
+                </rollingPolicy>
+                <immediateFlush>true</immediateFlush>
+                <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
+                    <pattern>%date %level [%thread] %logger{40} %msg%n</pattern>
+                </encoder>
+            </appender>
+        </sift>
+    </appender>
+
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
+            <pattern>%date %level [%thread] %logger{40} %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <!-- valid logging levels: TRACE, DEBUG, INFO, WARN, ERROR -->
+
+    <!-- Deprecation Log -->
+    <logger name="deprecation" level="WARN" additivity="false">
+        <appender-ref ref="DEPRECATION_FILE"/>
+    </logger>
+
+    <logger name="org.apache.nifi" level="INFO"/>
+    <logger name="org.apache.nifi.processors" level="WARN"/>
+    <logger name="org.apache.nifi.processors.standard.LogAttribute" level="INFO"/>
+    <logger name="org.apache.nifi.processors.standard.LogMessage" level="INFO"/>
+    <logger name="org.apache.nifi.controller.repository.StandardProcessSession" level="WARN" />
+    <logger name="org.apache.parquet.hadoop.InternalParquetRecordReader" level="WARN" />
+
+    <logger name="org.apache.zookeeper.ClientCnxn" level="ERROR" />
+    <logger name="org.apache.zookeeper.server.NIOServerCnxn" level="ERROR" />
+    <logger name="org.apache.zookeeper.server.NIOServerCnxnFactory" level="ERROR" />
+    <logger name="org.apache.zookeeper.server.NettyServerCnxnFactory" level="ERROR" />
+    <logger name="org.apache.zookeeper.server.quorum" level="ERROR" />
+    <logger name="org.apache.zookeeper.ZooKeeper" level="ERROR" />
+    <logger name="org.apache.zookeeper.server.PrepRequestProcessor" level="ERROR" />
+    <logger name="org.apache.nifi.controller.reporting.LogComponentStatuses" level="ERROR" />
+
+    <logger name="org.apache.calcite.runtime.CalciteException" level="OFF" />
+
+    <logger name="org.apache.curator.framework.recipes.leader.LeaderSelector" level="OFF" />
+    <logger name="org.apache.curator.ConnectionState" level="OFF" />
+
+    <!-- Logger for managing logging statements for nifi clusters. -->
+    <logger name="org.apache.nifi.cluster" level="INFO"/>
+
+    <!-- Logger for logging HTTP requests received by the web server. -->
+    <logger name="org.apache.nifi.server.JettyServer" level="INFO"/>
+
+    <!-- Logger for managing logging statements for jetty -->
+    <logger name="org.eclipse.jetty" level="INFO"/>
+
+    <!-- Suppress non-error messages due to excessive logging by class or library -->
+    <logger name="org.springframework" level="ERROR"/>
+    <logger name="org.springframework.security" level="INFO"/>
+
+    <!-- Suppress non-error messages due to known warning about redundant path annotation (NIFI-574) -->
+    <logger name="org.glassfish.jersey.internal.Errors" level="ERROR"/>
+
+    <!-- Suppress non-error messages due to Jetty AnnotationParser emitting a large amount of WARNS. Issue described in NIFI-5479. -->
+    <logger name="org.eclipse.jetty.annotations.AnnotationParser" level="ERROR"/>
+
+    <!-- Suppress non-error messages from SSHJ which was emitting large amounts of INFO logs by default -->
+    <logger name="net.schmizz.sshj" level="WARN" />
+    <logger name="com.hierynomus.sshj" level="WARN" />
+
+    <!-- Suppress non-error messages from SMBJ which was emitting large amounts of INFO logs by default -->
+    <logger name="com.hierynomus.smbj" level="WARN" />
+
+    <!-- Suppress non-error messages from AWS KCL which was emitting large amounts of INFO logs by default -->
+    <logger name="com.amazonaws.services.kinesis" level="WARN" />
+
+    <!-- Suppress non-error messages from Apache Atlas which was emitting large amounts of INFO logs by default -->
+    <logger name="org.apache.atlas" level="WARN"/>
+
+    <!-- Suppress non-error messages from JetBrains Xodus FileDataWriter related to FileChannel -->
+    <logger name="jetbrains.exodus.io.FileDataWriter" level="WARN" />
+
+    <!-- These log messages would normally go to the USER_FILE log, but they belong in the APP_FILE -->
+    <logger name="org.apache.nifi.web.security.requests" level="INFO" additivity="false">
+        <appender-ref ref="APP_FILE"/>
+    </logger>
+
+    <!--
+        Logger for capturing user events. We do not want to propagate these
+        log events to the root logger. These messages are only sent to the
+        user-log appender.
+    -->
+    <logger name="org.apache.nifi.web.security" level="INFO" additivity="false">
+        <appender-ref ref="USER_FILE"/>
+    </logger>
+    <logger name="org.apache.nifi.web.api.config" level="INFO" additivity="false">
+        <appender-ref ref="USER_FILE"/>
+    </logger>
+    <logger name="org.apache.nifi.authorization" level="INFO" additivity="false">
+        <appender-ref ref="USER_FILE"/>
+    </logger>
+    <logger name="org.apache.nifi.cluster.authorization" level="INFO" additivity="false">
+        <appender-ref ref="USER_FILE"/>
+    </logger>
+    <logger name="org.apache.nifi.web.api.AccessResource" level="INFO" additivity="false">
+        <appender-ref ref="USER_FILE"/>
+    </logger>
+    <logger name="org.opensaml" level="WARN" additivity="false">
+        <appender-ref ref="USER_FILE"/>
+    </logger>
+
+    <!-- Web Server Request Log -->
+    <logger name="org.apache.nifi.web.server.RequestLog" level="INFO" additivity="false">
+        <appender-ref ref="REQUEST_FILE"/>
+    </logger>
+
+    <!--
+        Logger for capturing Bootstrap logs and NiFi's standard error and standard out.
+    -->
+    <logger name="org.apache.nifi.bootstrap" level="INFO" additivity="false">
+        <appender-ref ref="BOOTSTRAP_FILE" />
+    </logger>
+    <logger name="org.apache.nifi.bootstrap.Command" level="INFO" additivity="false">
+        <appender-ref ref="CONSOLE" />
+        <appender-ref ref="BOOTSTRAP_FILE" />
+    </logger>
+
+    <!-- Everything written to NiFi's Standard Out will be logged with the logger org.apache.nifi.StdOut at INFO level -->
+    <logger name="org.apache.nifi.StdOut" level="INFO" additivity="false">
+        <appender-ref ref="BOOTSTRAP_FILE" />
+    </logger>
+
+    <!-- Everything written to NiFi's Standard Error will be logged with the logger org.apache.nifi.StdErr at ERROR level -->
+    <logger name="org.apache.nifi.StdErr" level="ERROR" additivity="false">
+        <appender-ref ref="BOOTSTRAP_FILE" />
+    </logger>
+
+    <root level="INFO">
+        <appender-ref ref="APP_FILE" />
+    </root>
+
+    <root level="INFO">
+        <appender-ref ref="DEDICATED_LOGGING" />
+    </root>
+
+</configuration>

--- a/configs/nifi.properties
+++ b/configs/nifi.properties
@@ -122,7 +122,11 @@ nifi.components.status.snapshot.frequency=1 min
 
 # Site to Site properties
 nifi.remote.input.host=
+{{ if .Values.properties.httpsPort }}
 nifi.remote.input.secure=true
+{{ else }}
+nifi.remote.input.secure=false
+{{ end }}
 nifi.remote.input.socket.port={{.Values.properties.siteToSite.port}}
 nifi.remote.input.http.enabled=true
 nifi.remote.input.http.transaction.ttl=30 sec
@@ -132,7 +136,8 @@ nifi.remote.contents.cache.expiration=30 secs
 nifi.web.war.directory=./lib
 nifi.web.proxy.host={{.Values.properties.webProxyHost}}
 nifi.web.https.port={{.Values.properties.httpsPort}}
-nifi.web.http.host=
+nifi.web.http.host={{.Values.properties.webHttpHost}}
+nifi.web.http.port={{.Values.properties.httpPort}}
 nifi.web.http.network.interface.default=
 nifi.web.https.host={{.Values.properties.webHttpsHost}}
 nifi.web.https.network.interface.default=
@@ -177,7 +182,7 @@ nifi.security.truststore=/opt/nifi/nifi-current/conf/truststore.p12
 nifi.security.truststoreType=PKCS12
 nifi.security.truststorePasswd=
 nifi.security.user.authorizer=managed-authorizer
-{{ else }}
+{{ else if .Values.properties.httpsPort }}
 nifi.security.keystore=./conf/keystore.p12
 nifi.security.keystoreType=PKCS12
 nifi.security.keystorePasswd=
@@ -187,6 +192,16 @@ nifi.security.truststoreType=PKCS12
 nifi.security.truststorePasswd=
 nifi.security.user.login.identity.provider=single-user-provider
 nifi.security.user.authorizer=single-user-authorizer
+{{else}}
+nifi.security.keystore=
+nifi.security.keystoreType=
+nifi.security.keystorePasswd=
+nifi.security.keyPasswd=
+nifi.security.truststore=
+nifi.security.truststoreType=
+nifi.security.truststorePasswd=
+nifi.security.user.login.identity.provider=
+nifi.security.user.authorizer=
 {{end}}
 nifi.security.needClientAuth={{.Values.properties.needClientAuth}}
 
@@ -221,7 +236,11 @@ nifi.security.user.knox.audiences=
 
 # cluster common properties (all nodes must have same values) #
 nifi.cluster.protocol.heartbeat.interval=5 sec
+{{ if .Values.properties.httpsPort}}
 nifi.cluster.protocol.is.secure=true
+{{ else }}
+nifi.cluster.protocol.is.secure=false
+{{ end }}
 
 # cluster node properties (only configure for cluster nodes) #
 nifi.cluster.is.node={{.Values.properties.isNode}}

--- a/configs/nifi.properties
+++ b/configs/nifi.properties
@@ -14,7 +14,13 @@
 # limitations under the License.
 
 # Core Properties #
+{{ $isVersion2 := hasPrefix "2." .Values.image.tag -}}
+
+{{ if $isVersion2 -}}
+nifi.flow.configuration.file=../data/flow.json.gz
+{{ else -}}
 nifi.flow.configuration.file=../data/flow.xml.gz
+{{ end -}}
 nifi.flow.configuration.archive.enabled=true
 nifi.flow.configuration.archive.dir=../data/archive/
 nifi.flow.configuration.archive.max.time={{.Values.properties.flowArchiveMaxTime}}

--- a/templates/NOTES.txt
+++ b/templates/NOTES.txt
@@ -1,6 +1,14 @@
+{{- $port := (.Values.service.httpsPort | default .Values.service.httpPort) }}
 To access the NiFi UI via kubectl port forwarding,
 wait until the cluster is ready and then run:
 
-kubectl port-forward -n {{ .Release.Namespace}} svc/{{ .Release.Name }} {{ .Values.service.httpsPort }}:{{ .Values.service.httpsPort }}
+kubectl port-forward -n {{ .Release.Namespace}} svc/{{ .Release.Name }} {{ $port }}:{{ $port }}
 
-...and point your web browser to https://localhost:{{ .Values.service.httpsPort }}/nifi/
+...and point your web browser to http{{ if .Values.properties.httpsPort }}s{{ end }}://localhost:{{ $port }}/nifi/
+
+{{- if .Values.ingress.enabled }}
+...and since you enabled the ingress, you can access NiFi at:
+{{- range .Values.ingress.hosts }}
+http://{{ . }}/nifi
+{{ end }}
+{{ end }}

--- a/templates/NOTES.txt
+++ b/templates/NOTES.txt
@@ -1,4 +1,4 @@
-{{- $port := (.Values.service.httpsPort | default .Values.service.httpPort) }}
+{{- $port := .Values.service.httpPort }}
 To access the NiFi UI via kubectl port forwarding,
 wait until the cluster is ready and then run:
 

--- a/templates/ingress-processors.yaml
+++ b/templates/ingress-processors.yaml
@@ -11,8 +11,12 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: {{ .Release.Name | quote }}
     heritage: {{ .Release.Service | quote }}
-{{- with .Values.ingress.processors.annotations }}
   annotations:
+{{- if .Values.traefik.tlsOptions.enabled }}
+    traefik.ingress.kubernetes.io/router.tls: "true"
+    traefik.ingress.kubernetes.io/router.tls.options: {{ .Release.Namespace}}-{{ $fullName }}-tls-option
+{{- end }}
+{{- with .Values.ingress.processors.annotations }}
 {{ toYaml . | indent 4 }}
 {{- end }}
 spec:

--- a/templates/ingress-processors.yaml
+++ b/templates/ingress-processors.yaml
@@ -1,29 +1,27 @@
 ---
-{{- if .Values.ingress.enabled -}}
+{{- if .Values.ingress.processors.enabled -}}
 {{- $fullName := include "apache-nifi.fullname" $ -}}
-{{- $ingressPath := .Values.ingress.path -}}
-{{- $ingressHttpPort := (.Values.service.httpsPort | default .Values.service.httpPort) -}}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: {{ template "apache-nifi.fullname" $ }}-ingress
+  name: {{ template "apache-nifi.fullname" $ }}-ingress-processors
   namespace: {{ .Release.Namespace }}
   labels:
     app: {{ include "apache-nifi.name" . | quote }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: {{ .Release.Name | quote }}
     heritage: {{ .Release.Service | quote }}
-{{- with .Values.ingress.annotations }}
+{{- with .Values.ingress.processors.annotations }}
   annotations:
 {{ toYaml . | indent 4 }}
 {{- end }}
 spec:
-{{- if .Values.ingress.className }}
-  ingressClassName: {{ .Values.ingress.className | quote }}
+{{- if .Values.ingress.processors.className }}
+  ingressClassName: {{ .Values.ingress.processors.className | quote }}
 {{- end }}
-{{- if .Values.ingress.tls }}
+{{- if .Values.ingress.processors.tls }}
   tls:
-  {{- range .Values.ingress.tls }}
+  {{- range .Values.ingress.processors.tls }}
     - hosts:
       {{- range .hosts }}
         - {{ . | quote }}
@@ -32,16 +30,18 @@ spec:
   {{- end }}
 {{- end }}
   rules:
-  {{- range .Values.ingress.hosts }}
-    - host: {{ . }}
+  {{- range .Values.ingress.processors.hosts }}
+    - host: {{ .host }}
       http:
         paths:
-          - path: {{ $ingressPath }}
-            pathType: Prefix
+        {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .type }}
             backend:
               service:
-                name: {{ $fullName }}
+                name: {{ .serviceName }}
                 port: 
-                  number: {{ $ingressHttpPort }}
+                  number: {{ .port }}
+        {{- end }}
   {{- end }}
 {{- end }}

--- a/templates/ingress-processors.yaml
+++ b/templates/ingress-processors.yaml
@@ -14,7 +14,7 @@ metadata:
   annotations:
 {{- if .Values.traefik.tlsOptions.enabled }}
     traefik.ingress.kubernetes.io/router.tls: "true"
-    traefik.ingress.kubernetes.io/router.tls.options: {{ .Release.Namespace}}-{{ $fullName }}-tls-option
+    traefik.ingress.kubernetes.io/router.tls.options: {{ .Release.Namespace}}-{{ $fullName }}-tls-option@kubernetescrd
 {{- end }}
 {{- with .Values.ingress.processors.annotations }}
 {{ toYaml . | indent 4 }}

--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -13,8 +13,12 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: {{ .Release.Name | quote }}
     heritage: {{ .Release.Service | quote }}
-{{- with .Values.ingress.annotations }}
   annotations:
+{{- if .Values.traefik.tlsOptions.enabled }}
+    traefik.ingress.kubernetes.io/router.tls: "true"
+    traefik.ingress.kubernetes.io/router.tls.options: {{ .Release.Namespace}}-{{ $fullName }}-tls-option
+{{- end }}
+{{- with .Values.ingress.annotations }}
 {{ toYaml . | indent 4 }}
 {{- end }}
 spec:

--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -16,7 +16,7 @@ metadata:
   annotations:
 {{- if .Values.traefik.tlsOptions.enabled }}
     traefik.ingress.kubernetes.io/router.tls: "true"
-    traefik.ingress.kubernetes.io/router.tls.options: {{ .Release.Namespace}}-{{ $fullName }}-tls-option
+    traefik.ingress.kubernetes.io/router.tls.options: {{ .Release.Namespace}}-{{ $fullName }}-tls-option@kubernetescrd
 {{- end }}
 {{- with .Values.ingress.annotations }}
 {{ toYaml . | indent 4 }}

--- a/templates/servers_transport.yaml
+++ b/templates/servers_transport.yaml
@@ -1,0 +1,10 @@
+{{- if .Values.traefik.serversTransport.enabled }}
+apiVersion: traefik.io/v1alpha1
+kind: ServersTransport
+metadata:
+  name: {{ template "apache-nifi.fullname" . }}-transport
+  namespace: {{ .Release.Namespace }}
+
+spec: 
+  insecureSkipVerify: {{ .Values.traefik.serversTransport.insecureSkipVerify }}
+{{- end }}

--- a/templates/service.yaml
+++ b/templates/service.yaml
@@ -40,9 +40,12 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: {{ .Release.Name | quote }}
     heritage: {{ .Release.Service | quote }}
-{{- if .Values.service.annotations }}
+{{- if or .Values.service.annotations .Values.traefik.serversTransport.enabled }}
   annotations:
 {{ toYaml .Values.service.annotations | indent 4 }}
+{{- end }}
+{{- if .Values.traefik.serversTransport.enabled }}
+    traefik.ingress.kubernetes.io/service.serversTransport: {{ .Release.Namespace }}-{{ template "apache-nifi.fullname" . }}-transport@kubernetescrd
 {{- end }}
 spec:
   type: {{ .Values.service.type }}

--- a/templates/service.yaml
+++ b/templates/service.yaml
@@ -66,7 +66,7 @@ spec:
   {{- end }}
   ports:
   {{- if .Values.properties.httpsPort }}
-    - port: {{ .Values.service.httpsPort }}
+    - port: {{ .Values.service.httpPort }}
       name: https
       targetPort: {{ .Values.properties.httpsPort }}
   {{- else }}

--- a/templates/service.yaml
+++ b/templates/service.yaml
@@ -16,8 +16,13 @@ spec:
   type: {{ .Values.headless.type }}
   clusterIP: None
   ports:
+  {{- if .Values.properties.httpsPort }}
   - port: {{ .Values.properties.httpsPort }}
     name: https
+  {{- else }}
+  - port: {{ .Values.properties.httpPort }}
+    name: http
+  {{- end }}
   - port: {{ .Values.properties.clusterPort }}
     name: cluster
   - port: {{ .Values.properties.siteToSite.port }}
@@ -60,9 +65,15 @@ spec:
   {{- end }}
   {{- end }}
   ports:
+  {{- if .Values.properties.httpsPort }}
     - port: {{ .Values.service.httpsPort }}
       name: https
       targetPort: {{ .Values.properties.httpsPort }}
+  {{- else }}
+    - port: {{ .Values.service.httpPort }}
+      name: http
+      targetPort: {{ .Values.properties.httpPort }}
+  {{- end }}
       nodePort: {{ .Values.service.nodePort }}
     - port: {{ .Values.properties.siteToSite.port }}
       name: site-to-site

--- a/templates/service.yaml
+++ b/templates/service.yaml
@@ -65,15 +65,14 @@ spec:
   {{- end }}
   {{- end }}
   ports:
-  {{- if .Values.properties.httpsPort }}
     - port: {{ .Values.service.httpPort }}
+      {{- if .Values.properties.httpsPort }}
       name: https
       targetPort: {{ .Values.properties.httpsPort }}
-  {{- else }}
-    - port: {{ .Values.service.httpPort }}
+      {{- else }}
       name: http
       targetPort: {{ .Values.properties.httpPort }}
-  {{- end }}
+      {{- end }}
       nodePort: {{ .Values.service.nodePort }}
     - port: {{ .Values.properties.siteToSite.port }}
       name: site-to-site

--- a/templates/statefulset.yaml
+++ b/templates/statefulset.yaml
@@ -137,45 +137,11 @@ spec:
 {{- end }}
 
           cat "${NIFI_HOME}/conf/nifi.temp" > "${NIFI_HOME}/conf/nifi.properties"
+          cat "${NIFI_HOME}/conf/authorizers.temp" > "${NIFI_HOME}/conf/authorizers.xml"
 
 {{- if .Values.auth.ldap.enabled }}
           cat "${NIFI_HOME}/conf/authorizers.temp" > "${NIFI_HOME}/conf/authorizers.xml"
           cat "${NIFI_HOME}/conf/login-identity-providers-ldap.xml" > "${NIFI_HOME}/conf/login-identity-providers.xml"
-{{- else if .Values.auth.oidc.enabled }}
-          prop_replace nifi.security.user.login.identity.provider ''
-          prop_replace nifi.security.user.authorizer managed-authorizer
-          prop_replace nifi.security.user.oidc.discovery.url {{ .Values.auth.oidc.discoveryUrl }}
-          prop_replace nifi.security.user.oidc.client.id {{ .Values.auth.oidc.clientId }}
-          prop_replace nifi.security.user.oidc.client.secret {{ .Values.auth.oidc.clientSecret }}
-          prop_replace nifi.security.user.oidc.claim.identifying.user {{ .Values.auth.oidc.claimIdentifyingUser }}
-          xmlstarlet ed --inplace --delete "//authorizers/authorizer[identifier='single-user-authorizer']" "${NIFI_HOME}/conf/authorizers.xml"
-          xmlstarlet ed --inplace --update "//authorizers/userGroupProvider/property[@name='Users File']" -v './auth-conf/users.xml' "${NIFI_HOME}/conf/authorizers.xml"
-          xmlstarlet ed --inplace --delete "//authorizers/userGroupProvider/property[@name='Initial User Identity 1']" "${NIFI_HOME}/conf/authorizers.xml"
-          xmlstarlet ed --inplace \
-                        --subnode "authorizers/userGroupProvider" --type 'elem' -n 'property' \
-                          --value {{ .Values.auth.oidc.admin | quote }} \
-                        --insert "authorizers/userGroupProvider/property[not(@name)]" --type attr -n name \
-                          --value "Initial User Identity {{ .Values.replicaCount }}" \
-                        "${NIFI_HOME}/conf/authorizers.xml"
-          xmlstarlet ed --inplace --update "//authorizers/accessPolicyProvider/property[@name='Initial Admin Identity']" -v {{ .Values.auth.oidc.admin | quote }} "${NIFI_HOME}/conf/authorizers.xml"
-          xmlstarlet ed --inplace --update "//authorizers/accessPolicyProvider/property[@name='Authorizations File']" -v './auth-conf/authorizations.xml' "${NIFI_HOME}/conf/authorizers.xml"
-          {{- if .Values.properties.isNode }}
-                      xmlstarlet ed --inplace --delete "authorizers/accessPolicyProvider/property[@name='Node Identity 1']" "${NIFI_HOME}/conf/authorizers.xml"
-            {{ range untilStep 0 (int .Values.replicaCount) 1 }}
-                      xmlstarlet ed --inplace \
-                                    --subnode "authorizers/accessPolicyProvider" --type 'elem' -n 'property' \
-                                    --value "CN={{ template "apache-nifi.fullname" $ }}-{{ . }}.{{ template "apache-nifi.fullname" $ }}-headless.{{ $.Release.Namespace }}.svc.{{ $.Values.certManager.clusterDomain }}, OU=NIFI" \
-                                    --insert "authorizers/accessPolicyProvider/property[not(@name)]" --type attr -n name \
-                                    --value "Node Identity {{ . }}" \
-                                    "${NIFI_HOME}/conf/authorizers.xml"
-                      xmlstarlet ed --inplace \
-                                    --subnode "authorizers/userGroupProvider" --type 'elem' -n 'property' \
-                                    --value "CN={{ template "apache-nifi.fullname" $ }}-{{ . }}.{{ template "apache-nifi.fullname" $ }}-headless.{{ $.Release.Namespace }}.svc.{{ $.Values.certManager.clusterDomain }}, OU=NIFI" \
-                                    --insert "authorizers/userGroupProvider/property[not(@name)]" --type attr -n name \
-                                    --value "Initial User Identity {{ . }}" \
-                                    "${NIFI_HOME}/conf/authorizers.xml"
-            {{/* range untilStep 0 (int .Values.replicaCount ) 1 */}}{{ end }}
-          {{- end }}
 {{- else if .Values.auth.clientAuth.enabled }}
           cat "${NIFI_HOME}/conf/authorizers.temp" > "${NIFI_HOME}/conf/authorizers.xml"
           xmlstarlet ed --inplace --delete "//authorizers/authorizer[identifier='single-user-authorizer']" "${NIFI_HOME}/conf/authorizers.xml"
@@ -205,22 +171,6 @@ spec:
 {{- end }}
 
 {{- if .Values.certManager.enabled }}
-          xmlstarlet ed --inplace --delete "authorizers/accessPolicyProvider/property[@name='Node Identity 1']" "${NIFI_HOME}/conf/authorizers.xml"
-{{ range untilStep 0 (int .Values.replicaCount) 1 }}
-          xmlstarlet ed --inplace \
-                        --subnode "authorizers/accessPolicyProvider" --type 'elem' -n 'property' \
-                          --value "CN={{ template "apache-nifi.fullname" $ }}-{{ . }}.{{ template "apache-nifi.fullname" $ }}-headless.{{ $.Release.Namespace }}.svc.{{ $.Values.certManager.clusterDomain }}, OU=NIFI" \
-                        --insert "authorizers/accessPolicyProvider/property[not(@name)]" --type attr -n name \
-                          --value "Node Identity {{ . }}" \
-                        "${NIFI_HOME}/conf/authorizers.xml"
-          xmlstarlet ed --inplace \
-                        --subnode "authorizers/userGroupProvider" --type 'elem' -n 'property' \
-                          --value "CN={{ template "apache-nifi.fullname" $ }}-{{ . }}.{{ template "apache-nifi.fullname" $ }}-headless.{{ $.Release.Namespace }}.svc.{{ $.Values.certManager.clusterDomain }}, OU=NIFI" \
-                        --insert "authorizers/userGroupProvider/property[not(@name)]" --type attr -n name \
-                          --value "Initial User Identity {{ . }}" \
-                        "${NIFI_HOME}/conf/authorizers.xml"
-{{/* range untilStep 0 (int .Values.replicaCount ) 1 */}}{{ end }}
-
           prop_replace nifi.security.keystore "${NIFI_HOME}/tls/keystore.jks"
           prop_replace nifi.security.keystoreType JKS
           prop_replace nifi.security.keystorePasswd "{{ .Values.certManager.keystorePasswd }}"
@@ -451,7 +401,7 @@ spec:
 {{- end }}
           periodSeconds: 20
           tcpSocket:
-            port: {{ .Values.service.httpPort }}
+            port: {{ .Values.service.httpsPort | default .Values.service.httpPort }}
 #           exec:
 #             command:
 #             - bash
@@ -570,6 +520,9 @@ spec:
           - name: "flow-content"
             mountPath: /opt/nifi/data/flow.xml
             subPath: "flow.xml"
+          - name: "logback-xml"
+            mountPath: /opt/nifi/nifi-current/conf/logback.xml
+            subPath: "logback.xml"
           {{- range $secret := .Values.secrets }}
             {{- if $secret.mountPath }}
               {{- if $secret.keys }}
@@ -841,6 +794,12 @@ spec:
           items:
             - key: "flow.xml"
               path: "flow.xml"
+      - name: "logback-xml"
+        configMap:
+          name: {{ template "apache-nifi.fullname" . }}-config
+          items:
+            - key: "logback.xml"
+              path: "logback.xml"
 {{- if .Values.certManager.enabled }}
       - name: secret-reader-token
         secret:

--- a/templates/statefulset.yaml
+++ b/templates/statefulset.yaml
@@ -451,7 +451,7 @@ spec:
 {{- end }}
           periodSeconds: 20
           tcpSocket:
-            port: {{ .Values.service.httpsPort | default .Values.service.httpPort }}
+            port: {{ .Values.service.httpPort }}
 #           exec:
 #             command:
 #             - bash

--- a/templates/statefulset.yaml
+++ b/templates/statefulset.yaml
@@ -299,7 +299,11 @@ spec:
           function offloadNode() {
               FQDN=$(hostname -f)
               echo "disconnecting node '$FQDN'"
+              {{- if .Values.properties.httpsPort }}
               baseUrl=https://${FQDN}:{{ .Values.properties.httpsPort }}
+              {{- else }}
+              baseUrl=http://${FQDN}:{{ .Values.properties.httpPort }}
+              {{- end }}
 
               echo "keystoreType=$(prop nifi.security.keystoreType)" > secure.properties
               echo "keystore=$(prop nifi.security.keystore)" >> secure.properties
@@ -320,7 +324,11 @@ spec:
               echo ""
               echo "get a connected node"
               connectedNode=$(jq -r 'first(.cluster.nodes|=sort_by(.address)| .cluster.nodes[] | select(.status=="CONNECTED")) | .address' nodes.json)
+              {{- if .Values.properties.httpsPort }}
               baseUrl=https://${connectedNode}:{{ .Values.properties.httpsPort }}
+              {{- else }}
+              baseUrl=http://${connectedNode}:{{ .Values.properties.httpPort }}
+              {{- end }}
               echo baseUrl ${baseUrl}
               echo ""
               echo "wait until node has state 'DISCONNECTED'"
@@ -377,6 +385,7 @@ spec:
           name: metrics
           protocol: TCP                  
 {{- end }}
+{{- if .Values.properties.httpsPort }}
         - containerPort: {{ .Values.properties.httpsPort }}
 {{- if .Values.sts.hostPort }}
           hostPort: {{ .Values.sts.hostPort }}
@@ -386,6 +395,32 @@ spec:
         - containerPort: {{ .Values.properties.clusterPort }}
           name: cluster
           protocol: TCP
+{{- else }}
+        - containerPort: {{ .Values.properties.httpPort }}
+{{- if .Values.sts.hostPort }}
+          hostPort: {{ .Values.sts.hostPort }}
+{{- end }}
+          name: http
+          protocol: TCP
+{{- end }}
+{{- if .Values.properties.siteToSite.port }}
+        - containerPort: {{ .Values.properties.siteToSite.port }}
+{{- if .Values.properties.siteToSite.hostPort }}
+          hostPort: {{ .Values.properties.siteToSite.hostPort }}
+{{- end }}
+          name: site-to-site
+          protocol: TCP
+{{- end }}
+{{- if .Values.containerPorts  }}
+{{ toYaml .Values.containerPorts | indent 8 }}
+{{- end }}
+        env:
+        - name: NIFI_ZOOKEEPER_CONNECT_STRING
+          value: {{ template "zookeeper.url" . }}
+{{- if not (or (.Values.auth.ldap.enabled) (.Values.auth.oidc.enabled)) }}
+        - name: NIFI_WEB_HTTPS_HOST
+          value:
+{{- end }}
 {{- if .Values.containerPorts  }}
 {{ toYaml .Values.containerPorts | indent 8 }}
 {{- end }}
@@ -416,7 +451,7 @@ spec:
 {{- end }}
           periodSeconds: 20
           tcpSocket:
-            port: {{ .Values.properties.httpsPort }}
+            port: {{ .Values.service.httpsPort | default .Values.service.httpPort }}
 #           exec:
 #             command:
 #             - bash
@@ -444,7 +479,11 @@ spec:
           failureThreshold: {{ .Values.sts.startupProbe.failureThreshold }}
           periodSeconds: {{ .Values.sts.startupProbe.periodSeconds }}
           tcpSocket:
+          {{- if .Values.properties.httpsPort }}
             port: {{ .Values.properties.httpsPort }}
+          {{- else }}
+            port: {{ .Values.properties.httpPort }}
+          {{- end }}
 {{- end }}
         livenessProbe:
 {{- if not .Values.sts.startupProbe.enabled }}
@@ -452,7 +491,11 @@ spec:
 {{- end }}
           periodSeconds: 60
           tcpSocket:
+          {{- if .Values.properties.httpsPort }}
             port: {{ .Values.properties.httpsPort }}
+          {{- else }}
+            port: {{ .Values.properties.httpPort }}
+          {{- end }}
         volumeMounts:
           - mountPath: /opt/nifi/nifi-current/logs
             {{- if and .Values.persistence.enabled .Values.persistence.subPath.enabled }}

--- a/templates/tls_options.yaml
+++ b/templates/tls_options.yaml
@@ -2,7 +2,7 @@
 apiVersion: traefik.io/v1alpha1
 kind: TLSOption
 metadata:
-  name: {{ template "nifi.fullname" . }}-tls-option
+  name: {{ template "apache-nifi.fullname" . }}-tls-option
   namespace: {{ .Release.Namespace }}
 
 spec:

--- a/templates/tls_options.yaml
+++ b/templates/tls_options.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.traefik.tlsOptions.enabled }}
+apiVersion: traefik.io/v1alpha1
+kind: TLSOption
+metadata:
+  name: {{ template "nifi.fullname" . }}-tls-option
+  namespace: {{ .Release.Namespace }}
+
+spec:
+  maxVersion: {{ .Values.traefik.tlsOptions.maxVersion | default "VersionTLS12" }}
+  minVersion: {{ .Values.traefik.tlsOptions.minVersion | default "VersionTLS12" }}
+{{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -193,7 +193,7 @@ headless:
 # ui service
 service:
   type: ClusterIP
-  httpsPort: 8443 # Make sure to change it to httpPort if you set httpsPort to null
+  httpPort: 8443 # Make sure to change it to properties.httpPort if you set properties.httpsPort to null
   # nodePort: 30236
   annotations: {}
     # loadBalancerIP:

--- a/values.yaml
+++ b/values.yaml
@@ -256,6 +256,11 @@ ingress:
       #       serviceName: processor02
       #       type: Prefix
 
+traefik:
+  serversTransport:
+    enabled: false
+    insecureSkipVerify: true
+
 # Amount of memory to give the NiFi java heap
 jvmMemory: 2g
 

--- a/values.yaml
+++ b/values.yaml
@@ -260,6 +260,10 @@ traefik:
   serversTransport:
     enabled: false
     insecureSkipVerify: true
+  tlsOptions:
+    enabled: false
+    minVersion: VersionTLS12
+    maxVersion: VersionTLS12
 
 # Amount of memory to give the NiFi java heap
 jvmMemory: 2g

--- a/values.yaml
+++ b/values.yaml
@@ -7,7 +7,7 @@ replicaCount: 1
 ##
 image:
   repository: apache/nifi
-  tag: "1.23.2"
+  tag: "1.25.0"
   pullPolicy: "IfNotPresent"
 
   ## Optionally specify an imagePullSecret.
@@ -91,7 +91,8 @@ properties:
   # use externalSecure for when inbound SSL is provided by nginx-ingress or other external mechanism
   externalSecure: false
   isNode: false
-  httpsPort: 8443
+  httpsPort: 8443 # Set this to null to disable secure configuration.
+  httpPort: 8080
   webProxyHost: # <clusterIP>:<NodePort> (If Nifi service is NodePort or LoadBalancer)
   clusterPort: 6007
   zkClientEnsembleTraker: false # https://issues.apache.org/jira/browse/NIFI-10481
@@ -192,7 +193,7 @@ headless:
 # ui service
 service:
   type: ClusterIP
-  httpsPort: 8443
+  httpsPort: 8443 # Make sure to change it to httpPort if you set httpsPort to null
   # nodePort: 30236
   annotations: {}
     # loadBalancerIP:
@@ -233,8 +234,27 @@ ingress:
   annotations: {}
   tls: []
   hosts: []
-  path: /
+  path: / # Change it to /nifi if you want to have a ingress for processors on the same host
   # If you want to change the default path, see this issue https://github.com/cetic/helm-nifi/issues/22
+  processors:
+    enabled: false
+    # className: nginx
+    annotations: {}
+    tls: []
+      # - hosts: 
+      #   - nifi.example.com
+      #   secretName: nifi-tls
+    hosts: []
+      # - host: nifi.example.com
+      #   paths: 
+      #     - path: /processor01
+      #       port: 7001
+      #       serviceName: processor01
+      #       type: Prefix
+      #     - path: /processor02
+      #       port: 7002
+      #       serviceName: processor02
+      #       type: Prefix
 
 # Amount of memory to give the NiFi java heap
 jvmMemory: 2g
@@ -249,7 +269,7 @@ sidecar:
 ## ref: http://kubernetes.io/docs/user-guide/persistent-volumes/
 ##
 persistence:
-  enabled: false
+  enabled: true
 
   # When creating persistent storage, the NiFi helm chart can either reference an already-defined
   # storage class by name, such as "standard" or can define a custom storage class by specifying


### PR DESCRIPTION
What I did:
1. Added support for ingress rules for each individual service we create for processors.
2. Added support for plain http setup (if you set .Values.propeties.httpsPort to something falsy, nifi will start in unsecured mode)
